### PR TITLE
PokeDB - Add comment feature in the Pop-up

### DIFF
--- a/src/modules/comments.js
+++ b/src/modules/comments.js
@@ -1,0 +1,16 @@
+export default (id, user, comment) => {
+  fetch(
+    'https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/d0HqiZcQvtTYVZAFmqCY/comments',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        item_id: id,
+        username: user,
+        comment,
+      }),
+    },
+  );
+};

--- a/src/modules/modal.js
+++ b/src/modules/modal.js
@@ -1,4 +1,5 @@
 import capitalize from './helpers.js';
+import addComment from './comments.js';
 
 export default async function populate(data, element) {
   const wrapper = document.createElement('div');
@@ -94,6 +95,7 @@ export default async function populate(data, element) {
         </ul>
       </div>
     </div>
+    <section class="comments"></section>
     <form class="flex flex-aic">
       <input id="fullname" type="text" placeholder="Your name" required />
       <textarea
@@ -110,5 +112,20 @@ export default async function populate(data, element) {
 
   document.querySelector('.close-btn').addEventListener('click', () => {
     wrapper.remove();
+  });
+
+  const form = document.querySelector('form');
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    addComment(
+      data.id,
+      form.elements.fullname.value,
+      form.elements.comment.value,
+    );
+    document.querySelector(
+      '.comments',
+    ).innerHTML += `<p>${form.elements.fullname.value}: ${form.elements.comment.value}</p>`;
+    form.reset();
+    form.focus();
   });
 }


### PR DESCRIPTION
In this pull request I added:
- A add comment file containing a function that posts data to the Involvement API;
- When the user clicks the submit button on the pop-up, the function is called;
- After the function is called, the most recent added comment is displayed in the comments section of the pop-up.